### PR TITLE
fix: modify the 'reset' function

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,7 +29,7 @@ export const useClock = ({
   const reset: (resetFrom?: number) => void = useCallback(
     (resetFrom?: number) => {
       clearInterval(intervalId.current);
-      setCounter(resetFrom ? resetFrom : from);
+      setCounter(resetFrom !== undefined ? resetFrom : from);
     },
     [from]
   );


### PR DESCRIPTION
I found a bug while changing the timer's time to 0.

The condition of the parameter calling setCounter has been changed.